### PR TITLE
Feature/manage double payment

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "name": "functions",
       "dependencies": {
-        "firebase-admin": "^10.0.2",
-        "firebase-functions": "^3.16.0"
+        "firebase-admin": "^10.3.0",
+        "firebase-functions": "^3.24.1"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.8.0",
@@ -19,7 +19,7 @@
         "typescript": "^4.5.4"
       },
       "engines": {
-        "node": "16"
+        "node": "14"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -65,79 +65,93 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/@fastify/busboy": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-1.2.1.tgz",
+      "integrity": "sha512-7PQA7EH43S0CxcOa9OeAnaeA0oQ+e/DHNPZwSQM9CQHW76jle5+OvLdibRp/Aafs9KXbLhxyjOTkRjWUbQEd3Q==",
+      "dependencies": {
+        "text-decoding": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@firebase/app-types": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.7.0.tgz",
-      "integrity": "sha512-6fbHQwDv2jp/v6bXhBw2eSRbNBpxHcd1NBF864UksSMVIqIyri9qpJB1Mn6sGZE+bnDsSQBC5j2TbMxYsJQkQg=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz",
+      "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q==",
+      "peer": true
     },
     "node_modules/@firebase/auth-interop-types": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
-      "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.7.tgz",
+      "integrity": "sha512-yA/dTveGGPcc85JP8ZE/KZqfGQyQTBCV10THdI8HTlP1GDvNrhr//J5jAt58MlsCOaO3XmC4DqScPBbtIsR/EA==",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
         "@firebase/util": "1.x"
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.12.tgz",
-      "integrity": "sha512-gAKwxo0Ev+rp7Px+Yr71WbcC0CM9Tevhv0g38ORp2p57HqGjY65D3MD+jTKGZl58N/0nmX6MRRKym3bq/3k1gw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.21.tgz",
+      "integrity": "sha512-12MMQ/ulfygKpEJpseYMR0HunJdlsLrwx2XcEs40M18jocy2+spyzHHEwegN3x/2/BLFBjR5247Etmz0G97Qpg==",
       "dependencies": {
-        "@firebase/util": "1.5.1",
+        "@firebase/util": "1.7.3",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.12.7.tgz",
-      "integrity": "sha512-HL2NMQ3Ce5YNM2MdEuACHmU9NQEwq2F64R0XK+CReph40skxp+A7TvlJDO5bTAC0s3l3ebgCA9VmxfJu5R6UAA==",
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.13.10.tgz",
+      "integrity": "sha512-KRucuzZ7ZHQsRdGEmhxId5jyM2yKsjsQWF9yv0dIhlxYg0D8rCVDZc/waoPKA5oV3/SEIoptF8F7R1Vfe7BCQA==",
       "dependencies": {
-        "@firebase/auth-interop-types": "0.1.6",
-        "@firebase/component": "0.5.12",
-        "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.5.1",
+        "@firebase/auth-interop-types": "0.1.7",
+        "@firebase/component": "0.5.21",
+        "@firebase/logger": "0.3.4",
+        "@firebase/util": "1.7.3",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.1.7.tgz",
-      "integrity": "sha512-T1mleRv2A8wyTV/jUuOdkN9Tl2lz0RGauqGc9nxP3AUzS9m3gIDN7u4CahZSdJlkR6tSU/MEWlfs5Q/oZStqxg==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.2.10.tgz",
+      "integrity": "sha512-fK+IgUUqVKcWK/gltzDU+B1xauCOfY6vulO8lxoNTkcCGlSxuTtwsdqjGkFmgFRMYjXFWWJ6iFcJ/vXahzwCtA==",
       "dependencies": {
-        "@firebase/component": "0.5.12",
-        "@firebase/database": "0.12.7",
-        "@firebase/database-types": "0.9.6",
-        "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.5.1",
+        "@firebase/component": "0.5.21",
+        "@firebase/database": "0.13.10",
+        "@firebase/database-types": "0.9.17",
+        "@firebase/logger": "0.3.4",
+        "@firebase/util": "1.7.3",
         "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.6.tgz",
-      "integrity": "sha512-E7U28X+FtVtug7EkIkaOXbdP8ghCPno21WWgEiDKsneY28N5WOwccfXqSzHgAAezkR40ht/ZqXlCsUhEpv6JXw==",
+      "version": "0.9.17",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.17.tgz",
+      "integrity": "sha512-YQm2tCZyxNtEnlS5qo5gd2PAYgKCy69tUKwioGhApCFThW+mIgZs7IeYeJo2M51i4LCixYUl+CvnOyAnb/c3XA==",
       "dependencies": {
-        "@firebase/app-types": "0.7.0",
-        "@firebase/util": "1.5.1"
+        "@firebase/app-types": "0.8.1",
+        "@firebase/util": "1.7.3"
       }
     },
+    "node_modules/@firebase/database-types/node_modules/@firebase/app-types": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.8.1.tgz",
+      "integrity": "sha512-p75Ow3QhB82kpMzmOntv866wH9eZ3b4+QbUY+8/DA5Zzdf1c8Nsk8B7kbFpzJt4wwHMdy5LTF5YUnoTc1JiWkw=="
+    },
     "node_modules/@firebase/logger": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.3.2.tgz",
-      "integrity": "sha512-lzLrcJp9QBWpo40OcOM9B8QEtBw2Fk1zOZQdvv+rWS6gKmhQBCEMc4SMABQfWdjsylBcDfniD1Q+fUX1dcBTXA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.3.4.tgz",
+      "integrity": "sha512-hlFglGRgZEwoyClZcGLx/Wd+zoLfGmbDkFx56mQt/jJ0XMbfPqwId1kiPl0zgdWZX+D8iH+gT6GuLPFsJWgiGw==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.5.1.tgz",
-      "integrity": "sha512-ojwPg8sKVcoU/kC1QdTrD+eUDyjQkZyiH9tlouXeZdAeDddCYNvHgIeBQhZt62WIcjlNhy1zro/xdV5nUUU38A==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.7.3.tgz",
+      "integrity": "sha512-wxNqWbqokF551WrJ9BIFouU/V5SL1oYCGx1oudcirdhadnQRFH5v1sjgGL7cUV/UsekSycygphdrF2lxBxOYKg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -1360,17 +1374,6 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
-    "node_modules/dicer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.1.tgz",
-      "integrity": "sha512-ObioMtXnmjYs3aRtpIJt9rgQSPCIhKVkFPip+E9GUDyWl8N435znUxK/JfNwGZJ2wnn5JKQ7Ly3vOK5Q5dylGA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2051,36 +2054,38 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-10.0.2.tgz",
-      "integrity": "sha512-MLH0SPmC4L0aCHvPjs1KThraru/T84T3hxiPY3uCH7NZEgE/T5n4GwecwU3RcM3X+br75BIBY7qhaR5uCxhdXA==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-10.3.0.tgz",
+      "integrity": "sha512-A0wgMLEjyVyUE+heyMJYqHRkPVjpebhOYsa47RHdrTM4ltApcx8Tn86sUmjqxlfh09gNnILAm7a8q5+FmgBYpg==",
       "dependencies": {
-        "@firebase/database-compat": "^0.1.1",
-        "@firebase/database-types": "^0.9.3",
+        "@fastify/busboy": "^1.1.0",
+        "@firebase/database-compat": "^0.2.0",
+        "@firebase/database-types": "^0.9.7",
         "@types/node": ">=12.12.47",
-        "dicer": "^0.3.0",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^2.0.2",
-        "node-forge": "^1.0.0"
+        "node-forge": "^1.3.1",
+        "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">=12.7.0"
       },
       "optionalDependencies": {
-        "@google-cloud/firestore": "^4.5.0",
-        "@google-cloud/storage": "^5.3.0"
+        "@google-cloud/firestore": "^4.15.1",
+        "@google-cloud/storage": "^5.18.3"
       }
     },
     "node_modules/firebase-functions": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.19.0.tgz",
-      "integrity": "sha512-FG4jurD8ymQ3hMVRgYU7dPhNoMRONxYFF1NrHrKed6YWnEvlYFDNXwGHqXQq66wyCuhCTbhMa6Dwqyng4z5tZw==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.24.1.tgz",
+      "integrity": "sha512-GYhoyOV0864HFMU1h/JNBXYNmDk2MlbvU7VO/5qliHX6u/6vhSjTJjlyCG4leDEI8ew8IvmkIC5QquQ1U8hAuA==",
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
         "cors": "^2.8.5",
         "express": "^4.17.1",
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.14",
+        "node-fetch": "^2.6.7"
       },
       "bin": {
         "firebase-functions": "lib/bin/firebase-functions.js"
@@ -2089,7 +2094,7 @@
         "node": "^8.13.0 || >=10.10.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0"
+        "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/firebase-functions-test": {
@@ -2470,9 +2475,9 @@
       }
     },
     "node_modules/http-parser-js": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.6.tgz",
-      "integrity": "sha512-vDlkRPDJn93swjcjqMSaGSPABbIarsr1TLAui/gLDXzV5VsJNdXNzMYDyNBLQkjWQCJ1uizu8T2oDMhmGt0PRA=="
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
+      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -3295,7 +3300,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "optional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -3312,9 +3316,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.0.tgz",
-      "integrity": "sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -4010,14 +4014,6 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "optional": true
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -4146,6 +4142,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/text-decoding": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-decoding/-/text-decoding-1.0.0.tgz",
+      "integrity": "sha512-/0TJD42KDnVwKmDK6jj3xP7E2MG7SHAOG4tyTgyUCRPdHwvkquYNLEQltmdMa3owq3TkddCVcTsoctJI8VQNKA=="
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4175,8 +4176,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "optional": true
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
@@ -4191,9 +4191,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -4336,7 +4336,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -4358,8 +4357,7 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "optional": true
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -4386,7 +4384,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "optional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/functions/package.json
+++ b/functions/package.json
@@ -14,8 +14,8 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "firebase-admin": "^10.0.2",
-    "firebase-functions": "^3.16.0"
+    "firebase-admin": "^10.3.0",
+    "firebase-functions": "^3.24.1"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.8.0",

--- a/src/api/stripeCheckOut.ts
+++ b/src/api/stripeCheckOut.ts
@@ -1,5 +1,8 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const stripe = require("stripe")(process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY);
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY as string, {
+  apiVersion: "2022-11-15"
+});
 
 export const stripeCheckOut = async (req: any, res: any) => {
   try {

--- a/src/pages/api/createStripeUser.ts
+++ b/src/pages/api/createStripeUser.ts
@@ -1,7 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import Stripe from "stripe";
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const stripe = require("stripe")(process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY);
+const stripe = new Stripe(process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY as string, {
+  apiVersion: "2022-11-15"
+});
 
 export default async function (req: NextApiRequest, res: NextApiResponse) {
   try {

--- a/src/pages/api/stripeCheckOut.ts
+++ b/src/pages/api/stripeCheckOut.ts
@@ -9,6 +9,23 @@ export default async function (req: NextApiRequest, res: NextApiResponse) {
   try {
     if (req.method !== "POST") throw new Error();
 
+    // 1. 生成したCheckout URLを一覧で取得
+    const { data: sessionList } = await stripe.checkout.sessions.list({
+      customer: req.body
+    });
+
+    // 2. 現在有効中のURLをフィルターする
+    const openSessionList = sessionList.filter(
+      (sessionItem) => sessionItem.status === "open"
+    );
+
+    // 3. 有効中のURLを無効化する
+    await Promise.all(
+      openSessionList.map((openSessionItem) =>
+        stripe.checkout.sessions.expire(openSessionItem.id)
+      )
+    );
+
     const session = await stripe.checkout.sessions.create({
       customer: req.body,
       line_items: [

--- a/src/pages/api/stripeCheckOut.ts
+++ b/src/pages/api/stripeCheckOut.ts
@@ -1,7 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import Stripe from "stripe";
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const stripe = require("stripe")(process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY);
+const stripe = new Stripe(process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY as string, {
+  apiVersion: "2022-11-15"
+});
 
 export default async function (req: NextApiRequest, res: NextApiResponse) {
   try {


### PR DESCRIPTION
## 【実装内容】

複数の決済URLを発行されても、最後に発行されたものだけを有効にする処理の実装

以下のコードは、顧客に紐づく過去に発行された決済リンクを無効にする処理
これを`stripe.checkout.sessions.create`の前に実装することで、最後に発行されたものだけを有効にできる

```jsx
    const { data: sessionList } = await stripe.checkout.sessions.list({
      customer: req.body
    });

    const openSessionList = sessionList.filter(
      (sessionItem) => sessionItem.status === "open"
    );

    await Promise.all(
      openSessionList.map((openSessionItem) =>
        stripe.checkout.sessions.expire(openSessionItem.id)
      )
    );
```