### PR TITLE
Homeページにプロダクト一覧を実装

### DIFF
--- a/src/api/stripeApi.ts
+++ b/src/api/stripeApi.ts
@@ -47,4 +47,16 @@ export class StripeApi {
 
     return res;
   }
+
+  async getProductList() {
+    const res = await fetch(`${this.apiUrl}/getProductList`, {
+      method: "GET",
+      headers: {
+        Accept: "text/plain",
+        "Content-Type": "text/plain"
+      }
+    });
+
+    return res;
+  }
 }

--- a/src/api/stripeApi.ts
+++ b/src/api/stripeApi.ts
@@ -1,5 +1,10 @@
 import { CurrentUser } from "~/store/auth";
 
+interface CreateCheckOutRequest {
+  customerId: string;
+  priceId: string;
+}
+
 export class StripeApi {
   private apiUrl: string;
 
@@ -22,14 +27,14 @@ export class StripeApi {
     return res;
   }
 
-  async checkOutForStripe(stripeCustomerId: string) {
+  async checkOutForStripe(createCheckOutRequest: CreateCheckOutRequest) {
     const res = await fetch(`${this.apiUrl}/stripeCheckOut`, {
       method: "POST",
       headers: {
         Accept: "application/json, text/plain, */*",
-        "Content-Type": "text/plain"
+        "Content-Type": "application/json"
       },
-      body: stripeCustomerId
+      body: JSON.stringify(createCheckOutRequest)
     });
 
     return res;

--- a/src/features/Home/HomePageTemplate.tsx
+++ b/src/features/Home/HomePageTemplate.tsx
@@ -9,21 +9,26 @@ import { Dropdown } from "~/libs/Dropdown";
 import { FlexContainer } from "~/components/layout/FlexContainer";
 import { Header } from "~/components/shared/Header";
 import { Overlay } from "~/components/shared/Overlay";
+import { ProductList } from "./components/ProductList";
 import { colors } from "styles/themes";
+import { HomePageProps } from "~/pages";
 
-export const HomePageTemplate = (): JSX.Element => {
+export const HomePageTemplate = ({
+  productList
+}: HomePageProps): JSX.Element => {
   const { currentUser, isLoading } = useRecoilValue(authState);
   const [isOpen, setOpen] = useRecoilState(dropdownState);
 
   if (isLoading) return <Loading size="xl" />;
 
-  const handleClick = async () => {
+  const handleClick = async (priceId: string) => {
     try {
       if (!currentUser) throw new Error();
 
-      const res = await stripeApi.checkOutForStripe(
-        currentUser.stripeCustomerId
-      );
+      const res = await stripeApi.checkOutForStripe({
+        customerId: currentUser.stripeCustomerId,
+        priceId
+      });
 
       const stripeCheckOutSession = await res.json();
 
@@ -43,15 +48,7 @@ export const HomePageTemplate = (): JSX.Element => {
       )}
       <main css={main}>
         <FlexContainer justifyContent="center" alignItems="center">
-          {currentUser ? (
-            currentUser.subscriptionStatus === "active" ? (
-              <p>あなたは有料会員です</p>
-            ) : (
-              <button onClick={handleClick}>課金する</button>
-            )
-          ) : (
-            <p>まずはログインから始めましょう！</p>
-          )}
+          <ProductList productList={productList} handleClick={handleClick} />
         </FlexContainer>
       </main>
     </Fragment>

--- a/src/features/Home/HomePageTemplate.tsx
+++ b/src/features/Home/HomePageTemplate.tsx
@@ -1,12 +1,11 @@
 import { Fragment } from "react";
 import { css } from "@emotion/react";
-import { Loading } from "@nextui-org/react";
+import { Container, Loading } from "@nextui-org/react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { authState } from "~/store/auth";
 import { dropdownState } from "~/libs/Dropdown/dropdownState";
 import { stripeApi } from "~/context/ApiContext";
 import { Dropdown } from "~/libs/Dropdown";
-import { FlexContainer } from "~/components/layout/FlexContainer";
 import { Header } from "~/components/shared/Header";
 import { Overlay } from "~/components/shared/Overlay";
 import { ProductList } from "./components/ProductList";
@@ -47,9 +46,9 @@ export const HomePageTemplate = ({
         </Overlay>
       )}
       <main css={main}>
-        <FlexContainer justifyContent="center" alignItems="center">
+        <Container>
           <ProductList productList={productList} handleClick={handleClick} />
-        </FlexContainer>
+        </Container>
       </main>
     </Fragment>
   );

--- a/src/features/Home/components/ProductList.tsx
+++ b/src/features/Home/components/ProductList.tsx
@@ -9,9 +9,9 @@ interface ProductListProps {
 
 export const ProductList = ({ productList, handleClick }: ProductListProps) => {
   return (
-    <Grid.Container gap={2} justify="flex-start">
+    <Grid.Container gap={6} justify="flex-start">
       {productList.map((product) => (
-        <Grid xs={6} sm={3} key={product.id}>
+        <Grid xs={6} sm={4} key={product.id}>
           <Card
             isPressable
             onPressStart={() => handleClick(product.default_price as string)}

--- a/src/features/Home/components/ProductList.tsx
+++ b/src/features/Home/components/ProductList.tsx
@@ -1,0 +1,54 @@
+import { Card, Grid, Row, Text } from "@nextui-org/react";
+import { StripeProduct } from "~/pages/api/getProductList";
+import { convertToMoney } from "~/utils/convertToMoney";
+
+interface ProductListProps {
+  productList: StripeProduct[];
+  handleClick: (priceId: string) => Promise<void>;
+}
+
+export const ProductList = ({ productList, handleClick }: ProductListProps) => {
+  return (
+    <Grid.Container gap={2} justify="flex-start">
+      {productList.map((product) => (
+        <Grid xs={6} sm={3} key={product.id}>
+          <Card
+            isPressable
+            onPressStart={() => handleClick(product.default_price as string)}
+          >
+            <Card.Body css={{ p: 0 }}>
+              <Card.Image
+                src={product.images[0]}
+                width="100%"
+                height={140}
+                alt={product.name}
+                objectFit="cover"
+              />
+            </Card.Body>
+            <Card.Footer css={{ justifyItems: "flex-start" }}>
+              <Row wrap="wrap" justify="space-between" align="center">
+                <Text size={16} b>
+                  {product.name}
+                </Text>
+                <Text
+                  size={14}
+                  css={{
+                    color: "$accents7",
+                    fontWeight: "$semibold",
+                    fontSize: "$sm"
+                  }}
+                >
+                  {convertToMoney(
+                    product.priceList.filter(
+                      (price) => price.id === product.default_price
+                    )[0].unit_amount
+                  )}
+                </Text>
+              </Row>
+            </Card.Footer>
+          </Card>
+        </Grid>
+      ))}
+    </Grid.Container>
+  );
+};

--- a/src/pages/api/getProductList.ts
+++ b/src/pages/api/getProductList.ts
@@ -1,0 +1,48 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import Stripe from "stripe";
+
+export interface StripeProduct extends Stripe.Product {
+  priceList: Stripe.Price[];
+}
+
+const stripe = new Stripe(process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY as string, {
+  apiVersion: "2022-11-15"
+});
+
+export default async function (req: NextApiRequest, res: NextApiResponse) {
+  try {
+    if (req.method !== "GET") throw new Error();
+
+    const productList: StripeProduct[] = [];
+
+    const response = await stripe.products.list({
+      active: true,
+      limit: 10
+    });
+
+    if (!response.data || response.data.length < 1) {
+      return res.status(200).json([]);
+    }
+
+    await Promise.all(
+      response.data.map(async (product, i) => {
+        const priceList = await stripe.prices.list({
+          product: product.id
+        });
+
+        productList.push({
+          ...response.data[i],
+          priceList: priceList.data
+        });
+      })
+    );
+
+    res.status(200).json(productList);
+  } catch (error) {
+    if (error instanceof Error) {
+      res.status(500).json(error.message);
+    }
+
+    console.log(error);
+  }
+}

--- a/src/pages/api/stripeCheckOut.ts
+++ b/src/pages/api/stripeCheckOut.ts
@@ -11,7 +11,7 @@ export default async function (req: NextApiRequest, res: NextApiResponse) {
 
     // 1. 生成したCheckout URLを一覧で取得
     const { data: sessionList } = await stripe.checkout.sessions.list({
-      customer: req.body
+      customer: req.body.customerId
     });
 
     // 2. 現在有効中のURLをフィルターする
@@ -27,16 +27,16 @@ export default async function (req: NextApiRequest, res: NextApiResponse) {
     );
 
     const session = await stripe.checkout.sessions.create({
-      customer: req.body,
+      customer: req.body.customerId,
       line_items: [
         {
-          price: process.env.NEXT_PUBLIC_STRIPE_API_KEY,
+          price: req.body.priceId,
           quantity: 1
         }
       ],
 
       mode: "subscription",
-      success_url: `${req.headers.origin}/success/?success=true`,
+      success_url: `${req.headers.origin}/dashboard`,
       cancel_url: `${req.headers.origin}/?canceled=true`
     });
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,25 @@
-import type { NextPage } from "next";
+import type { InferGetServerSidePropsType, NextPage } from "next";
+import { stripeApi } from "~/context/ApiContext";
 import { HomePageTemplate } from "~/features/Home/HomePageTemplate";
+import { StripeProduct } from "./api/getProductList";
 
-const Home: NextPage = (): JSX.Element => {
-  return <HomePageTemplate />;
+export type HomePageProps = InferGetServerSidePropsType<
+  typeof getServerSideProps
+>;
+
+export const getServerSideProps = async () => {
+  const res = await stripeApi.getProductList();
+  const productList = await res.json();
+
+  return {
+    props: {
+      productList: productList as StripeProduct[]
+    }
+  };
+};
+
+const Home: NextPage<HomePageProps> = ({ productList }): JSX.Element => {
+  return <HomePageTemplate productList={productList} />;
 };
 
 export default Home;


### PR DESCRIPTION
## 【実装内容】

1. プロダクトを取得する際に、紐づいている料金プランも一緒に取得

2. カードごとに決済ができる機能を実装
当座の決済は、Stripe側でデフォルトに設定されている料金プランで決済処理が走る

## 【Preview】

<img width="1470" alt="スクリーンショット 2023-02-18 11 02 27" src="https://user-images.githubusercontent.com/60911215/219825928-19028672-bae0-40a0-8aaf-84336b1941d1.png">

