### PR TITLE
契約したサブスク一覧を表示する機能の実装

### DIFF
--- a/src/api/stripeApi.ts
+++ b/src/api/stripeApi.ts
@@ -64,4 +64,17 @@ export class StripeApi {
 
     return res;
   }
+
+  async getSubscriptionList(stripeCustomerId: string) {
+    const res = await fetch(`${this.apiUrl}/getSubscriptionList`, {
+      method: "POST",
+      headers: {
+        Accept: "text/plain",
+        "Content-Type": "text/plain"
+      },
+      body: stripeCustomerId
+    });
+
+    return res;
+  }
 }

--- a/src/api/stripeApi.ts
+++ b/src/api/stripeApi.ts
@@ -77,4 +77,17 @@ export class StripeApi {
 
     return res;
   }
+
+  async cancelSubscription(stripeCustomerId: string) {
+    const res = await fetch(`${this.apiUrl}/cancelSubscription`, {
+      method: "POST",
+      headers: {
+        Accept: "text/plain",
+        "Content-Type": "text/plain"
+      },
+      body: stripeCustomerId
+    });
+
+    return res;
+  }
 }

--- a/src/features/DashBoard/DashBoardPageTemplate.tsx
+++ b/src/features/DashBoard/DashBoardPageTemplate.tsx
@@ -1,18 +1,15 @@
 import { Fragment } from "react";
-import { useRouter } from "next/router";
 import { css } from "@emotion/react";
-import { Table, Loading, Button } from "@nextui-org/react";
+import { useRouter } from "next/router";
+import { Loading } from "@nextui-org/react";
 import { useRecoilValue } from "recoil";
 import { authState } from "~/store/auth";
 import { Container } from "~/components/layout/Container";
 import { DashBoardPageProps } from "~/pages/dashboard";
 import { FlexContainer } from "~/components/layout/FlexContainer";
-import { PAYMENT_STATUS } from "./constants";
-import { convertToMoney } from "~/utils/convertToMoney";
-import { formatUnixTimeDate } from "~/utils/formatUnixTimeDate";
-import { colors } from "styles/themes";
-import { stripeApi } from "~/context/ApiContext";
+import { PaymentTable } from "./components/PaymentTable";
 import { SubscriptionTable } from "./components/SubscriptionTable";
+import { colors } from "styles/themes";
 
 export const DashBoardPageTemplate = ({
   paymentList,
@@ -49,34 +46,7 @@ export const DashBoardPageTemplate = ({
         </div>
         <div style={{ marginTop: 40 }}>
           <p css={label}>注文履歴</p>
-          <Table
-            aria-label="Example static collection table"
-            css={{
-              height: "auto",
-              fontSize: "1.4rem"
-            }}
-          >
-            <Table.Header>
-              <Table.Column>金額</Table.Column>
-              <Table.Column>ステータス</Table.Column>
-              <Table.Column>作成日</Table.Column>
-            </Table.Header>
-            <Table.Body>
-              {paymentList.map((payment) => (
-                <Table.Row key={payment.id}>
-                  <Table.Cell>
-                    {convertToMoney(payment.amount_total)}
-                  </Table.Cell>
-                  <Table.Cell>
-                    {PAYMENT_STATUS[payment.payment_status]}
-                  </Table.Cell>
-                  <Table.Cell>
-                    {formatUnixTimeDate(payment.created, "jp", true)}
-                  </Table.Cell>
-                </Table.Row>
-              ))}
-            </Table.Body>
-          </Table>
+          <PaymentTable paymentList={paymentList} />
         </div>
       </Container>
     </main>

--- a/src/features/DashBoard/DashBoardPageTemplate.tsx
+++ b/src/features/DashBoard/DashBoardPageTemplate.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "react";
 import { useRouter } from "next/router";
 import { css } from "@emotion/react";
-import { Table, Loading } from "@nextui-org/react";
+import { Table, Loading, Button } from "@nextui-org/react";
 import { useRecoilValue } from "recoil";
 import { authState } from "~/store/auth";
 import { Container } from "~/components/layout/Container";
@@ -11,12 +11,14 @@ import { PAYMENT_STATUS } from "./constants";
 import { convertToMoney } from "~/utils/convertToMoney";
 import { formatUnixTimeDate } from "~/utils/formatUnixTimeDate";
 import { colors } from "styles/themes";
+import { stripeApi } from "~/context/ApiContext";
 
 export const DashBoardPageTemplate = ({
-  paymentList
+  paymentList,
+  subscriptionList
 }: DashBoardPageProps): JSX.Element => {
   const { currentUser, isLoading } = useRecoilValue(authState);
-  const { push } = useRouter();
+  const { push, reload } = useRouter();
 
   if (isLoading) return <Loading size="xl" />;
 
@@ -24,6 +26,16 @@ export const DashBoardPageTemplate = ({
     push("/");
     return <Fragment />;
   }
+
+  const handleClick = async (stripeCustomerId: string) => {
+    try {
+      await stripeApi.cancelSubscription(stripeCustomerId);
+
+      reload();
+    } catch (error) {
+      console.error(error);
+    }
+  };
 
   return (
     <main css={main}>
@@ -40,33 +52,84 @@ export const DashBoardPageTemplate = ({
             </p>
           </FlexContainer>
         </FlexContainer>
-        <p css={label}>注文履歴</p>
-        <Table
-          aria-label="Example static collection table"
-          css={{
-            height: "auto",
-            fontSize: "1.4rem"
-          }}
-        >
-          <Table.Header>
-            <Table.Column>金額</Table.Column>
-            <Table.Column>ステータス</Table.Column>
-            <Table.Column>作成日</Table.Column>
-          </Table.Header>
-          <Table.Body>
-            {paymentList.map((payment) => (
-              <Table.Row key={payment.id}>
-                <Table.Cell>{convertToMoney(payment.amount_total)}</Table.Cell>
-                <Table.Cell>
-                  {PAYMENT_STATUS[payment.payment_status]}
-                </Table.Cell>
-                <Table.Cell>
-                  {formatUnixTimeDate(payment.created, "jp", true)}
-                </Table.Cell>
-              </Table.Row>
-            ))}
-          </Table.Body>
-        </Table>
+        <div>
+          <p css={label}>サブスク一覧</p>
+          <Table
+            aria-label="Example static collection table"
+            css={{
+              height: "auto",
+              fontSize: "1.4rem"
+            }}
+          >
+            <Table.Header>
+              <Table.Column>金額</Table.Column>
+              <Table.Column>ステータス</Table.Column>
+              <Table.Column>契約日</Table.Column>
+              <Table.Column>契約更新日</Table.Column>
+              <Table.Column>cancel</Table.Column>
+            </Table.Header>
+            <Table.Body>
+              {subscriptionList.map((subscription) => (
+                <Table.Row key={subscription.id}>
+                  <Table.Cell>
+                    {convertToMoney(
+                      subscription.items.data[0].price.unit_amount
+                    )}
+                  </Table.Cell>
+                  <Table.Cell>{subscription.status}</Table.Cell>
+                  <Table.Cell>
+                    {formatUnixTimeDate(subscription.start_date, "jp")}
+                  </Table.Cell>
+                  <Table.Cell>
+                    {formatUnixTimeDate(subscription.current_period_end, "jp")}
+                  </Table.Cell>
+                  <Table.Cell>
+                    {subscription.status === "active" && (
+                      <Button
+                        auto
+                        color="error"
+                        onClick={() => handleClick(subscription.id)}
+                      >
+                        解約する
+                      </Button>
+                    )}
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </div>
+        <div style={{ marginTop: 40 }}>
+          <p css={label}>注文履歴</p>
+          <Table
+            aria-label="Example static collection table"
+            css={{
+              height: "auto",
+              fontSize: "1.4rem"
+            }}
+          >
+            <Table.Header>
+              <Table.Column>金額</Table.Column>
+              <Table.Column>ステータス</Table.Column>
+              <Table.Column>作成日</Table.Column>
+            </Table.Header>
+            <Table.Body>
+              {paymentList.map((payment) => (
+                <Table.Row key={payment.id}>
+                  <Table.Cell>
+                    {convertToMoney(payment.amount_total)}
+                  </Table.Cell>
+                  <Table.Cell>
+                    {PAYMENT_STATUS[payment.payment_status]}
+                  </Table.Cell>
+                  <Table.Cell>
+                    {formatUnixTimeDate(payment.created, "jp", true)}
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </div>
       </Container>
     </main>
   );

--- a/src/features/DashBoard/DashBoardPageTemplate.tsx
+++ b/src/features/DashBoard/DashBoardPageTemplate.tsx
@@ -12,13 +12,14 @@ import { convertToMoney } from "~/utils/convertToMoney";
 import { formatUnixTimeDate } from "~/utils/formatUnixTimeDate";
 import { colors } from "styles/themes";
 import { stripeApi } from "~/context/ApiContext";
+import { SubscriptionTable } from "./components/SubscriptionTable";
 
 export const DashBoardPageTemplate = ({
   paymentList,
   subscriptionList
 }: DashBoardPageProps): JSX.Element => {
   const { currentUser, isLoading } = useRecoilValue(authState);
-  const { push, reload } = useRouter();
+  const { push } = useRouter();
 
   if (isLoading) return <Loading size="xl" />;
 
@@ -26,16 +27,6 @@ export const DashBoardPageTemplate = ({
     push("/");
     return <Fragment />;
   }
-
-  const handleClick = async (stripeCustomerId: string) => {
-    try {
-      await stripeApi.cancelSubscription(stripeCustomerId);
-
-      reload();
-    } catch (error) {
-      console.error(error);
-    }
-  };
 
   return (
     <main css={main}>
@@ -54,50 +45,7 @@ export const DashBoardPageTemplate = ({
         </FlexContainer>
         <div>
           <p css={label}>サブスク一覧</p>
-          <Table
-            aria-label="Example static collection table"
-            css={{
-              height: "auto",
-              fontSize: "1.4rem"
-            }}
-          >
-            <Table.Header>
-              <Table.Column>金額</Table.Column>
-              <Table.Column>ステータス</Table.Column>
-              <Table.Column>契約日</Table.Column>
-              <Table.Column>契約更新日</Table.Column>
-              <Table.Column>cancel</Table.Column>
-            </Table.Header>
-            <Table.Body>
-              {subscriptionList.map((subscription) => (
-                <Table.Row key={subscription.id}>
-                  <Table.Cell>
-                    {convertToMoney(
-                      subscription.items.data[0].price.unit_amount
-                    )}
-                  </Table.Cell>
-                  <Table.Cell>{subscription.status}</Table.Cell>
-                  <Table.Cell>
-                    {formatUnixTimeDate(subscription.start_date, "jp")}
-                  </Table.Cell>
-                  <Table.Cell>
-                    {formatUnixTimeDate(subscription.current_period_end, "jp")}
-                  </Table.Cell>
-                  <Table.Cell>
-                    {subscription.status === "active" && (
-                      <Button
-                        auto
-                        color="error"
-                        onClick={() => handleClick(subscription.id)}
-                      >
-                        解約する
-                      </Button>
-                    )}
-                  </Table.Cell>
-                </Table.Row>
-              ))}
-            </Table.Body>
-          </Table>
+          <SubscriptionTable subscriptionList={subscriptionList} />
         </div>
         <div style={{ marginTop: 40 }}>
           <p css={label}>注文履歴</p>

--- a/src/features/DashBoard/components/PaymentTable.tsx
+++ b/src/features/DashBoard/components/PaymentTable.tsx
@@ -1,0 +1,38 @@
+import { Table } from "@nextui-org/react";
+import Stripe from "stripe";
+import { convertToMoney } from "~/utils/convertToMoney";
+import { formatUnixTimeDate } from "~/utils/formatUnixTimeDate";
+import { PAYMENT_STATUS } from "../constants";
+
+interface PaymentTableProps {
+  paymentList: Stripe.Checkout.Session[];
+}
+
+export const PaymentTable = ({ paymentList }: PaymentTableProps) => {
+  return (
+    <Table
+      aria-label="Example static collection table"
+      css={{
+        height: "auto",
+        fontSize: "1.4rem"
+      }}
+    >
+      <Table.Header>
+        <Table.Column>金額</Table.Column>
+        <Table.Column>ステータス</Table.Column>
+        <Table.Column>作成日</Table.Column>
+      </Table.Header>
+      <Table.Body>
+        {paymentList.map((payment) => (
+          <Table.Row key={payment.id}>
+            <Table.Cell>{convertToMoney(payment.amount_total)}</Table.Cell>
+            <Table.Cell>{PAYMENT_STATUS[payment.payment_status]}</Table.Cell>
+            <Table.Cell>
+              {formatUnixTimeDate(payment.created, "jp", true)}
+            </Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+};

--- a/src/features/DashBoard/components/SubscriptionTable.tsx
+++ b/src/features/DashBoard/components/SubscriptionTable.tsx
@@ -1,0 +1,71 @@
+import { Button, Table } from "@nextui-org/react";
+import { useRouter } from "next/router";
+import Stripe from "stripe";
+import { stripeApi } from "~/context/ApiContext";
+import { convertToMoney } from "~/utils/convertToMoney";
+import { formatUnixTimeDate } from "~/utils/formatUnixTimeDate";
+
+interface SubscriptionTableProps {
+  subscriptionList: Stripe.Subscription[];
+}
+
+export const SubscriptionTable = ({
+  subscriptionList
+}: SubscriptionTableProps) => {
+  const { reload } = useRouter();
+
+  const handleClick = async (stripeCustomerId: string) => {
+    try {
+      await stripeApi.cancelSubscription(stripeCustomerId);
+
+      reload();
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <Table
+      aria-label="Example static collection table"
+      css={{
+        height: "auto",
+        fontSize: "1.4rem"
+      }}
+    >
+      <Table.Header>
+        <Table.Column>金額</Table.Column>
+        <Table.Column>ステータス</Table.Column>
+        <Table.Column>契約日</Table.Column>
+        <Table.Column>契約更新日</Table.Column>
+        <Table.Column>cancel</Table.Column>
+      </Table.Header>
+      <Table.Body>
+        {subscriptionList.map((subscription) => (
+          <Table.Row key={subscription.id}>
+            <Table.Cell>
+              {convertToMoney(subscription.items.data[0].price.unit_amount)}
+            </Table.Cell>
+            <Table.Cell>{subscription.status}</Table.Cell>
+            <Table.Cell>
+              {formatUnixTimeDate(subscription.start_date, "jp")}
+            </Table.Cell>
+            <Table.Cell>
+              {formatUnixTimeDate(subscription.current_period_end, "jp")}
+            </Table.Cell>
+            <Table.Cell>
+              {subscription.status === "active" && (
+                <Button
+                  auto
+                  color="error"
+                  onClick={() => handleClick(subscription.id)}
+                >
+                  解約する
+                </Button>
+              )}
+            </Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+};

--- a/src/pages/api/cancelSubscription.ts
+++ b/src/pages/api/cancelSubscription.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY as string, {
+  apiVersion: "2022-11-15"
+});
+
+export default async function (req: NextApiRequest, res: NextApiResponse) {
+  try {
+    if (req.method !== "POST") throw new Error();
+
+    const canceledSubscription = await stripe.subscriptions.del(req.body);
+
+    res.status(200).json({ canceledSubscription });
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      res.status(500).json(err.message);
+    }
+
+    console.log(err);
+  }
+}

--- a/src/pages/api/getSubscriptionList.ts
+++ b/src/pages/api/getSubscriptionList.ts
@@ -1,0 +1,26 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY as string, {
+  apiVersion: "2022-11-15"
+});
+
+export default async function (req: NextApiRequest, res: NextApiResponse) {
+  try {
+    if (req.method !== "POST") throw new Error();
+
+    const data = await stripe.subscriptions.list({
+      limit: 10,
+      customer: req.body,
+      status: "all"
+    });
+
+    res.status(200).json(data);
+  } catch (error) {
+    if (error instanceof Error) {
+      res.status(500).json(error.message);
+    }
+
+    console.log(error);
+  }
+}

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -13,15 +13,31 @@ export const getServerSideProps = async () => {
   );
   const paymentList = await res.json();
 
+  const response = await stripeApi.getSubscriptionList(
+    process.env.NEXT_PUBLIC_CUSTOMER_ID as string
+  );
+  const subscriptionList = await response.json();
+
+  console.log(subscriptionList);
+
   return {
-    props: { paymentList: paymentList.data as Stripe.Checkout.Session[] }
+    props: {
+      paymentList: paymentList.data as Stripe.Checkout.Session[],
+      subscriptionList: subscriptionList.data as Stripe.Subscription[]
+    }
   };
 };
 
 const DashBoardPage: NextPage<DashBoardPageProps> = ({
-  paymentList
+  paymentList,
+  subscriptionList
 }): JSX.Element => {
-  return <DashBoardPageTemplate paymentList={paymentList} />;
+  return (
+    <DashBoardPageTemplate
+      paymentList={paymentList}
+      subscriptionList={subscriptionList}
+    />
+  );
 };
 
 export default DashBoardPage;


### PR DESCRIPTION
## 【実装内容】

1. 解約するボタンから、サブスクリプションをキャンセルすることが可能

2. 現在は全てのサブスクリプションを取得するように実装
（契約中だけ、解約済みのものだけ、といったFilterをかけることも可能）

3. 各テーブルをComponent化しました

## 【Preview】

<img width="1470" alt="スクリーンショット 2023-02-18 16 28 45" src="https://user-images.githubusercontent.com/60911215/219847763-9ad5734f-0b2e-46e4-a897-7f94c568e7fc.png">

