### PR TITLE
Firebase認証のため、DashboardページはSSRをやめてCSRに変更

### DIFF
--- a/src/hoc/withAuthenticated.tsx
+++ b/src/hoc/withAuthenticated.tsx
@@ -1,0 +1,26 @@
+import { ComponentType, Fragment } from "react";
+import { useRouter } from "next/router";
+import { useRecoilValueLoadable } from "recoil";
+import { authState } from "~/store/auth";
+
+export const withAuthenticated = <P extends {} = {}>(
+  Element: ComponentType<P>
+) => {
+  return (props: Omit<P, keyof {}>) => {
+    const { contents: currentUser, state } = useRecoilValueLoadable(authState);
+    const router = useRouter();
+
+    if (!router.isReady) return <Fragment />;
+
+    if (state === "loading") return <Fragment />;
+
+    if (state === "hasError") return <p>Error page</p>;
+
+    if (!currentUser) {
+      router.push("/");
+      return <Fragment />;
+    }
+
+    return <Element {...props} />;
+  };
+};

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,43 +1,16 @@
-import type { InferGetServerSidePropsType, NextPage } from "next";
-import Stripe from "stripe";
-import { stripeApi } from "~/context/ApiContext";
+import type { NextPage } from "next";
+import { Fragment } from "react";
+import { useRecoilValue } from "recoil";
 import { DashBoardPageTemplate } from "~/features/DashBoard/DashBoardPageTemplate";
+import { withAuthenticated } from "~/hoc/withAuthenticated";
+import { authState } from "~/store/auth";
 
-export type DashBoardPageProps = InferGetServerSidePropsType<
-  typeof getServerSideProps
->;
+const DashBoardPage: NextPage = (): JSX.Element => {
+  const { currentUser } = useRecoilValue(authState);
 
-export const getServerSideProps = async () => {
-  const res = await stripeApi.getPaymentList(
-    process.env.NEXT_PUBLIC_CUSTOMER_ID as string
-  );
-  const paymentList = await res.json();
+  if (!currentUser) return <Fragment />;
 
-  const response = await stripeApi.getSubscriptionList(
-    process.env.NEXT_PUBLIC_CUSTOMER_ID as string
-  );
-  const subscriptionList = await response.json();
-
-  console.log(subscriptionList);
-
-  return {
-    props: {
-      paymentList: paymentList.data as Stripe.Checkout.Session[],
-      subscriptionList: subscriptionList.data as Stripe.Subscription[]
-    }
-  };
+  return <DashBoardPageTemplate currentUser={currentUser} />;
 };
 
-const DashBoardPage: NextPage<DashBoardPageProps> = ({
-  paymentList,
-  subscriptionList
-}): JSX.Element => {
-  return (
-    <DashBoardPageTemplate
-      paymentList={paymentList}
-      subscriptionList={subscriptionList}
-    />
-  );
-};
-
-export default DashBoardPage;
+export default withAuthenticated(DashBoardPage);


### PR DESCRIPTION
## 【実装内容】

1. 認証完了後にデータフェッチを行う必要があるため`HOC`を導入

2. データフェッチする処理は`useEffect`で制御してるけど、普通にやばいw


