### PR TITLE
返金機能の実装

### DIFF
--- a/src/api/stripeApi.ts
+++ b/src/api/stripeApi.ts
@@ -103,4 +103,17 @@ export class StripeApi {
 
     return res;
   }
+
+  async createRepayment(paymentId: string) {
+    const res = await fetch(`${this.apiUrl}/createRepayment`, {
+      method: "POST",
+      headers: {
+        Accept: "text/plain",
+        "Content-Type": "text/plain"
+      },
+      body: paymentId
+    });
+
+    return res;
+  }
 }

--- a/src/features/DashBoard/components/PaymentTable.tsx
+++ b/src/features/DashBoard/components/PaymentTable.tsx
@@ -10,7 +10,7 @@ interface PaymentTableProps {
 }
 
 export const PaymentTable = ({ paymentList }: PaymentTableProps) => {
-  const handleClick = async (invoiceId: string) => {
+  const createReceipt = async (invoiceId: string) => {
     try {
       const res = await stripeApi.getReceipt(invoiceId);
 
@@ -21,6 +21,18 @@ export const PaymentTable = ({ paymentList }: PaymentTableProps) => {
       console.error(error);
     }
   };
+
+  // const createRepayment = async (paymentId: string) => {
+  //   try {
+  //     const res = await stripeApi.createRepayment(paymentId);
+
+  //     const data = await res.json();
+
+  //     console.log(data);
+  //   } catch (error) {
+  //     console.error(error);
+  //   }
+  // };
 
   return (
     <Table
@@ -36,6 +48,7 @@ export const PaymentTable = ({ paymentList }: PaymentTableProps) => {
         <Table.Column>ステータス</Table.Column>
         <Table.Column>作成日</Table.Column>
         <Table.Column>領収書</Table.Column>
+        {/* <Table.Column>返金</Table.Column> */}
       </Table.Header>
       <Table.Body>
         {paymentList.map((payment) => (
@@ -48,12 +61,22 @@ export const PaymentTable = ({ paymentList }: PaymentTableProps) => {
             </Table.Cell>
             <Table.Cell>
               <Button
-                color="warning"
-                onClick={() => handleClick(payment.invoice as string)}
+                color="success"
+                onClick={() => createReceipt(payment.invoice as string)}
+                disabled={!payment.invoice}
               >
                 作成
               </Button>
             </Table.Cell>
+            {/* <Table.Cell>
+              <Button
+                color="error"
+                onClick={() => createRepayment(payment.charge)}
+                disabled={payment.refunded}
+              >
+                申請
+              </Button>
+            </Table.Cell> */}
           </Table.Row>
         ))}
       </Table.Body>

--- a/src/pages/api/createRepayment.ts
+++ b/src/pages/api/createRepayment.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY as string, {
+  apiVersion: "2022-11-15"
+});
+
+export default async function (req: NextApiRequest, res: NextApiResponse) {
+  try {
+    if (req.method !== "POST") throw new Error();
+
+    const refund = await stripe.refunds.create({ charge: req.body });
+
+    res.status(200).json({ refund: refund });
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      res.status(500).json(err.message);
+    }
+
+    console.log(err);
+  }
+}


### PR DESCRIPTION
## 【実装内容】

1. 返金機能の実装
→ 「返金を申請する」といったユースケースを想定できなかったため、コメントアウト
本来はキャンセル処理などが走った際に裏側で走らせるべきだと思う

2. 領収書の発行ができない履歴にはdisabledを付与
→ ちょっと原因わからんけどエラーが出るので当座の対応
