### PR TITLE
請求書払い機能の実装

### DIFF
--- a/src/api/stripeApi.ts
+++ b/src/api/stripeApi.ts
@@ -116,4 +116,17 @@ export class StripeApi {
 
     return res;
   }
+
+  async createInvoice(createInvoiceRequest: CreateCheckOutRequest) {
+    const res = await fetch(`${this.apiUrl}/createInvoice`, {
+      method: "POST",
+      headers: {
+        Accept: "application/json, text/plain, */*",
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(createInvoiceRequest)
+    });
+
+    return res;
+  }
 }

--- a/src/features/Home/components/ProductList.tsx
+++ b/src/features/Home/components/ProductList.tsx
@@ -4,7 +4,7 @@ import { convertToMoney } from "~/utils/convertToMoney";
 
 interface ProductListProps {
   productList: StripeProduct[];
-  handleClick: (priceId: string) => Promise<void>;
+  handleClick: (product: StripeProduct) => Promise<void>;
 }
 
 export const ProductList = ({ productList, handleClick }: ProductListProps) => {
@@ -12,10 +12,7 @@ export const ProductList = ({ productList, handleClick }: ProductListProps) => {
     <Grid.Container gap={6} justify="flex-start">
       {productList.map((product) => (
         <Grid xs={6} sm={4} key={product.id}>
-          <Card
-            isPressable
-            onPressStart={() => handleClick(product.default_price as string)}
-          >
+          <Card isPressable onPressStart={() => handleClick(product)}>
             <Card.Body css={{ p: 0 }}>
               <Card.Image
                 src={product.images[0]}

--- a/src/pages/api/createInvoice.ts
+++ b/src/pages/api/createInvoice.ts
@@ -1,0 +1,51 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY as string, {
+  apiVersion: "2022-11-15"
+});
+
+export default async function (req: NextApiRequest, res: NextApiResponse) {
+  try {
+    if (req.method !== "POST") throw new Error();
+
+    // 1. 生成したCheckout URLを一覧で取得
+    const { data: sessionList } = await stripe.checkout.sessions.list({
+      customer: req.body.customerId
+    });
+
+    // 2. 現在有効中のURLをフィルターする
+    const openSessionList = sessionList.filter(
+      (sessionItem) => sessionItem.status === "open"
+    );
+
+    // 3. 有効中のURLを無効化する
+    await Promise.all(
+      openSessionList.map((openSessionItem) =>
+        stripe.checkout.sessions.expire(openSessionItem.id)
+      )
+    );
+
+    const session = await stripe.invoices.create({
+      customer: req.body.customerId,
+      collection_method: "send_invoice",
+      days_until_due: 7
+    });
+
+    await stripe.invoiceItems.create({
+      customer: req.body.customerId,
+      price: req.body.priceId,
+      invoice: session.id
+    });
+
+    const invoice = await stripe.invoices.sendInvoice(session.id);
+
+    res.status(200).json({ url: invoice.invoice_pdf });
+  } catch (err: unknown) {
+    console.log(err);
+
+    if (err instanceof Error) {
+      res.status(500).json(err.message);
+    }
+  }
+}

--- a/src/pages/api/stripeCheckOut.ts
+++ b/src/pages/api/stripeCheckOut.ts
@@ -37,7 +37,7 @@ export default async function (req: NextApiRequest, res: NextApiResponse) {
 
       mode: "subscription",
       success_url: `${req.headers.origin}/dashboard`,
-      cancel_url: `${req.headers.origin}/?canceled=true`
+      cancel_url: `${req.headers.origin}`
     });
 
     res.status(200).json({ url: session.url });


### PR DESCRIPTION
## 【実装内容】

1. 請求書払い機能
→ 請求書を発行し、メールに送付する機能
「契約」と「決済」にラグがあるため、Webhookによる制御が本来は必要である

2. 単発決済か継続決済かによって条件分岐する処理の追加
→ 本来そういうユースケースはないと思うので、デザインを見直すべき

3. キャンセル時のリダイレクト先を修正
→ `cancel=true`が残ってしまうことに違和感を感じたため削除
それによって処理が変わる場合は残してもいいと思う🙆